### PR TITLE
dispose VM if it is disposable

### DIFF
--- a/solution/WellFired.Guacamole.Unity.Editor/GuacamoleWindow.cs
+++ b/solution/WellFired.Guacamole.Unity.Editor/GuacamoleWindow.cs
@@ -156,6 +156,7 @@ namespace WellFired.Guacamole.Unity.Editor
 			{
 				// ReSharper disable once DelegateSubtraction
 				EditorApplication.update -= Update;
+				DisposeBindingContext();
 			}
 		}
 
@@ -238,6 +239,8 @@ namespace WellFired.Guacamole.Unity.Editor
 
 		private void ResetForSomeReason()
 		{
+			DisposeBindingContext();
+			
 			NativeRendererHelper.LaunchedAssembly = Assembly.GetExecutingAssembly();
 
 			if (_initializationContext == null)
@@ -296,6 +299,14 @@ namespace WellFired.Guacamole.Unity.Editor
 		public bool MatchesMainContent(Type mainContent)
 		{
 			return _initializationContext.MainContentType == mainContent;
+		}
+
+		private void DisposeBindingContext()
+		{
+			if (_window != null && _window.BindingContext is System.IDisposable disposable)
+			{
+				disposable.Dispose();
+			}
 		}
 	}
 }


### PR DESCRIPTION
In .Peek, .Peek VM listen to FileSystemWatcher.

When we open .Peek, 2 instances of .Peek VM are created in a roll, one in 
GuacamoleWindow.cs --> OnGUI

And right after in 
GuacamoleWindow.cs --> Launch

(This is because OnGUI will be called once at Unity Window creation before the function Launch is executed)

It ends that each time a report is deleted or added, at least two instance of .Peek VM receive the event.

Disposing .Peek VM and unlistening FileSystemWatcher solve the problem.

